### PR TITLE
Fix select field with statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class Select {
     if (
       /^[a-zA-Z_1-9]+([.])(`)[a-zA-Z0-9-_]+(`)$/.test(field) ||
       /^[a-zA-Z_1-9]+([.])([*])$/.test(field) ||
-      /^[A-Z ]+([(])[a-zA-Z0-9* _=<>(,&).`]+([)])$/.test(field)
+      /^[A-Z ]+([(])[a-zA-Z0-9* _=<>(,&).`!']+([)])$/.test(field)
     )
       f += `${field}`;
     else


### PR DESCRIPTION

Not working with query like this:
```query.select("COALESCE(SUM(IF(wallet.`fund_amount` > 0 AND wallet.`action` != 'refund', wallet.`fund_amount`, 0)),0)", "fund_in");```

So put ! and ' into resolve field name regex.